### PR TITLE
Upgrade zlib package to fix CVE-2018-25032

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Change
+- Upgrade zlib package to fix CVE-2018-25032; #11
 
 ## [v3.6.4-1] - 2022-02-10
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
-FROM registry.cloudogu.com/official/base:3.15.0-1
+FROM registry.cloudogu.com/official/base:3.15.3-1
 LABEL name="official/postfix" \
       version="3.6.4-1" \
       maintainer=hello@cloudogu.com
 
 # INSTALL POSTFIX
-RUN apk add --update postfix openrc supervisor rsyslog \
-	&& rm -rf /var/cache/apk/*
+RUN set -o errexit \
+  && set -o nounset \
+  && set -o pipefail \
+  && apk update \
+  && apk upgrade \
+  && apk add --update postfix openrc supervisor rsyslog \
+  && rm -rf /var/cache/apk/*
 
 COPY resources /
 


### PR DESCRIPTION
### Change
- Upgrade zlib package to fix CVE-2018-25032
- Upgrade base image to 3.15.3-1

Resolves #11 