### PR TITLE
Feature/13 add sasl auth configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- support for SASL authentication (#13)
 
 ## [v3.6.4-2] - 2022-04-06
 ### Change
-- Upgrade zlib package to fix CVE-2018-25032; #11
+- Upgrade zlib package to fix CVE-2018-25032; (#11)
 
 ## [v3.6.4-1] - 2022-02-10
 ### Fixed

--- a/docs/development/Send_Mails_locally_de.md
+++ b/docs/development/Send_Mails_locally_de.md
@@ -49,24 +49,31 @@ Konkret müssen folgende Schritte ausgeführt werden:
 MailHog unterstützt keine Authentifizerung, aus diesem Grund kann mithilfe des Tools [E-MailRelay](http://emailrelay.sourceforge.net/index.html) 
 ein Proxy vor dem MailHog aufgebaut werden.
 
-Dazu muss E-MailRelay [heruntergeladen](http://emailrelay.sourceforge.net/Download.html), entpackt und installiert `sudo ./configure && make && make install` werden. 
+Dazu muss E-MailRelay [heruntergeladen](http://emailrelay.sourceforge.net/Download.html), 
+entpackt und installiert `sudo ./configure && sudo make && sudo make install` werden. 
+
+Für die Authentifizierung kann eine Password-Datei angelegt werden, die z.B. so aussehen kann:
+
+secret.auth
+```
+server plain adminuser adminpw
+```
 
 E-MailRelay kann mittels 
 ```
-sudo emailrelay -t --as-server --forward-on-disconnect --log --verbose --log-file mailrelay.log --log-time --port 587` als Proxy vor MailHog gestartet werden.
-``` 
+sudo emailrelay -t --as-server --forward-on-disconnect --log --verbose --log-file mailrelay.log --log-time --port 587 --forward-to localhost:1025 --server-auth ./secret.auth
+```
+als Proxy vor MailHog gestartet werden.
+
 Der Parameter `-t` startet den Proxy in einer Terminal-Sitzung. Das macht es einfacher, den Server neu zu starten.
 Der Relay-Host muss auf die mit dem `-port` spezifizierte Adresse zeigen. 
 ```
 etcdctl set /config/postfix/relayhost 192.168.56.1:587
 ```
 
-### SASL Authentifizierung
-SASL Authentifizierung kann mit dem Parameter `--server-auth <server-auth-file>` getestet werden. 
-Dazu muss am spezifizierten Pfad eine Datei angelegt werden in der Server, username und password hinterlegt werden.
-Eine gute Anleitung hierzu kann [hier](https://github.com/aclemons/emailrelay/blob/master/doc/reference.md#authentication) eingesehen werden. 
-Für SASL Authentifizierung muss der in der Datei hinterlegten Username und Passwort im etcd hinterlegt werden.
-  ```
-  etcdctl set /config/postfix/sasl_username <username>
-  etcdctl set /config/postfix/sasl_password <password>
-  ```
+Anschließend kann das entsprechende Passwort für Postfix konfiguriert werden.
+Beim Verschicken von Mails wird dann die SASL-Authentifizierung verwendet:
+```
+etcdctl set /config/postfix/sasl_username adminuser
+etcdctl set /config/postfix/sasl_password adminpw
+```

--- a/docs/development/Send_Mails_locally_de.md
+++ b/docs/development/Send_Mails_locally_de.md
@@ -43,3 +43,30 @@ Konkret müssen folgende Schritte ausgeführt werden:
   <strg>+<d>
   ```
 * In Web-Oberfläche vom MailHog - ```localhost:8025``` - Mail-Empfang prüfen
+
+
+## Einrichtung eines Proxy vor MailHog zum testen von Authentifizerungsworkflows
+MailHog unterstützt keine Authentifizerung, aus diesem Grund kann mithilfe des Tools [E-MailRelay](http://emailrelay.sourceforge.net/index.html) 
+ein Proxy vor dem MailHog aufgebaut werden.
+
+Dazu muss E-MailRelay [heruntergeladen](http://emailrelay.sourceforge.net/Download.html), entpackt und installiert `sudo ./configure && make && make install` werden. 
+
+E-MailRelay kann mittels 
+```
+sudo emailrelay -t --as-server --forward-on-disconnect --log --verbose --log-file mailrelay.log --log-time --port 587` als Proxy vor MailHog gestartet werden.
+``` 
+Der Parameter `-t` startet den Proxy in einer Terminal-Sitzung. Das macht es einfacher, den Server neu zu starten.
+Der Relay-Host muss auf die mit dem `-port` spezifizierte Adresse zeigen. 
+```
+etcdctl set /config/postfix/relayhost 192.168.56.1:587
+```
+
+### SASL Authentifizierung
+SASL Authentifizierung kann mit dem Parameter `--server-auth <server-auth-file>` getestet werden. 
+Dazu muss am spezifizierten Pfad eine Datei angelegt werden in der Server, username und password hinterlegt werden.
+Eine gute Anleitung hierzu kann [hier](https://github.com/aclemons/emailrelay/blob/master/doc/reference.md#authentication) eingesehen werden. 
+Für SASL Authentifizierung muss der in der Datei hinterlegten Username und Passwort im etcd hinterlegt werden.
+  ```
+  etcdctl set /config/postfix/sasl_username <username>
+  etcdctl set /config/postfix/sasl_password <password>
+  ```

--- a/docs/development/Send_Mails_locally_en.md
+++ b/docs/development/Send_Mails_locally_en.md
@@ -49,24 +49,31 @@ Specifically, the following steps need to be performed:
 MailHog does not support authentication, therefore using the tool [E-MailRelay](http://emailrelay.sourceforge.net/index.html)
 tool to set up a proxy in front of MailHog.
 
-To do this, E-MailRelay must be [downloaded](http://emailrelay.sourceforge.net/Download.html), unpacked and installed (`sudo ./configure && make && make install`).
+To do this, E-MailRelay must be [downloaded](http://emailrelay.sourceforge.net/Download.html),
+unpacked and installed `sudo ./configure && sudo make && sudo make install`.
 
-E-MailRelay can be started using
+For the authentication a password file can be created, which can look like this for example
+
+secret.auth
 ```
-sudo emailrelay -t --as-server --forward-on-disconnect --log --verbose --log-file mailrelay.log --log-time --port 587` as proxy before MailHog.
-``` 
-The `-t` parameter starts the proxy in a terminal session. This makes it easier to restart the server. 
-The relay host must point to the address specified by `-port`.
+server plain adminuser adminpw
+```
+
+E-MailRelay can be created using
+```
+sudo emailrelay -t --as-server --forward-on-disconnect --log --verbose --log-file mailrelay.log --log-time --port 587 --forward-to localhost:1025 --server-auth ./secret.auth
+```
+can be started as a proxy before MailHog.
+
+The `-t` parameter starts the proxy in a terminal session. This makes it easier to restart the server.
+The relay host must point to the address specified with the `-port`.
 ```
 etcdctl set /config/postfix/relayhost 192.168.56.1:587
 ```
 
-### SASL authentication
-SASL authentication can be tested with the `--server-auth <server-auth-file>` parameter.
-To do this, a file must be created at the specified path in which server, username and password are stored.
-A good tutorial for this can be found [here](https://github.com/aclemons/emailrelay/blob/master/doc/reference.md#authentication).
-For SASL authentication this username and password must be stored in etcd.
-  ```
-  etcdctl set /config/postfix/sasl_username <username>
-  etcdctl set /config/postfix/sasl_password <password>
-  ```
+Afterwards the appropriate password for Postfix can be configured.
+SASL authentication is then used when sending mails:
+```
+etcdctl set /config/postfix/sasl_username adminuser
+etcdctl set /config/postfix/sasl_password adminpw
+```

--- a/docs/development/Send_Mails_locally_en.md
+++ b/docs/development/Send_Mails_locally_en.md
@@ -43,3 +43,30 @@ Specifically, the following steps need to be performed:
   <strg>+<d>
   ```
 * In web interface of MailHog - ```localhost:8025`` - check mail reception
+
+
+## Setting up a proxy in front of MailHog to test authentication workflows.
+MailHog does not support authentication, therefore using the tool [E-MailRelay](http://emailrelay.sourceforge.net/index.html)
+tool to set up a proxy in front of MailHog.
+
+To do this, E-MailRelay must be [downloaded](http://emailrelay.sourceforge.net/Download.html), unpacked and installed (`sudo ./configure && make && make install`).
+
+E-MailRelay can be started using
+```
+sudo emailrelay -t --as-server --forward-on-disconnect --log --verbose --log-file mailrelay.log --log-time --port 587` as proxy before MailHog.
+``` 
+The `-t` parameter starts the proxy in a terminal session. This makes it easier to restart the server. 
+The relay host must point to the address specified by `-port`.
+```
+etcdctl set /config/postfix/relayhost 192.168.56.1:587
+```
+
+### SASL authentication
+SASL authentication can be tested with the `--server-auth <server-auth-file>` parameter.
+To do this, a file must be created at the specified path in which server, username and password are stored.
+A good tutorial for this can be found [here](https://github.com/aclemons/emailrelay/blob/master/doc/reference.md#authentication).
+For SASL authentication this username and password must be stored in etcd.
+  ```
+  etcdctl set /config/postfix/sasl_username <username>
+  etcdctl set /config/postfix/sasl_password <password>
+  ```

--- a/docs/operations/Configure_Dogu_de.md
+++ b/docs/operations/Configure_Dogu_de.md
@@ -32,6 +32,12 @@ Postfix-Dogu bietet die folgenden Einstellungen:
   etcdctl set /config/postfix/relayhost <Wert für den Relayhost>
   ```
 
+### SASL Authentifizierung
+
+* Pfad des Konfigurationsschlüssels: `sasl_username` __und__ `sasl_password`
+* Sind beide Schlüssel vorhanden wird beim start SASL Authentifizierung konfiguriert 
+* Optional
+
 ### SMTP TLS Sicherheitsstufe
 
 * Pfad des Konfigurationsschlüssels: `smtp_tls_security_level`

--- a/docs/operations/Configure_Dogu_en.md
+++ b/docs/operations/Configure_Dogu_en.md
@@ -32,6 +32,12 @@ the following settings:
   etcdctl set /config/postfix/relayhost <value for the relay host>
   ```
 
+### SASL authentication
+
+* Path of the configuration key: `sasl_username` __and__ `sasl_password`.
+* If both keys are present, SASL authentication is configured at startup.
+* Optional
+
 ### SMTP TLS security level
 
 * Configuration key path: `smtp_tls_security_level`

--- a/dogu.json
+++ b/dogu.json
@@ -17,6 +17,17 @@
       "Description": "The next-hop destination of non-local mail"
     },
     {
+      "Name": "sasl_username",
+      "Description": "username for sasl authentication",
+      "Optional": true
+    },
+    {
+      "Name": "sasl_password",
+      "Description": "password for sasl authentication, if the mail relay server needs an md5 encrypted password pass the encrypted password in here otherwise plain",
+      "Optional": true,
+      "Encrypted": false
+    },
+    {
       "Name": "smtp_tls_security_level",
       "Description": "The default SMTP TLS security level for the Postfix SMTP client",
       "Optional": true

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -64,7 +64,7 @@ if [ "${POSTFIX_SASL_USER}" != "NOT_SET" ] && [ "${POSTFIX_SASL_PASSWORD}" != "N
       echo "found SASL pw and user ... configure Postfix to use SASL authentication"
 
       # SASL security in postfix
-      echo "${MAILRELAY} ${POSFIX_SASL_USER}:${POSFIX_SASL_PASSWORD}"> /etc/postfix/sasl_passwd
+      echo "${MAILRELAY} ${POSTFIX_SASL_USER}:${POSTFIX_SASL_PASSWORD}"> /etc/postfix/sasl_passwd
       postmap /etc/postfix/sasl_passwd
 
       postconf -e smtp_sasl_auth_enable="yes" # enable SASL authentication in the Postfix SMTP client. By default, the Postfix SMTP client uses no authentication.

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -70,8 +70,6 @@ if [ "${POSTFIX_SASL_USER}" != "NOT_SET" ] && [ "${POSTFIX_SASL_PASSWORD}" != "N
       postconf -e smtp_sasl_auth_enable="yes" # enable SASL authentication in the Postfix SMTP client. By default, the Postfix SMTP client uses no authentication.
       postconf -e smtp_sasl_security_options="noanonymous" # removes the prohibition on plaintext password
       postconf -e smtp_sasl_password_maps="lmdb:/etc/postfix/sasl_passwd" #hash:/ is deprecated using lmdb:/ instead
-      # postconf -e smtp_tls_security_level="encrypt"
-      # postconf -e smtp_tls_wrappermode="yes" # "wrappermode" protocol, which uses TCP port 465 on the SMTP server (Postfix 3.0 and later), needs minimum security_level=encrypt
 else
       echo "configure no SASL authentication"
 fi

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -33,8 +33,8 @@ function writeIntoFileAndSetIfConfigured {
 MAILRELAY=$(doguctl config relayhost)
 NAME=$(hostname)
 DOMAIN=$(doguctl config --global domain)
-POSFIX_SASL_USER=$(doguctl config sasl_username)
-POSFIX_SASL_PASSWORD=$(doguctl config sasl_password)
+POSTFIX_SASL_USER=$(doguctl config --default "NOT_SET" sasl_username)
+POSTFIX_SASL_PASSWORD=$(doguctl config --default "NOT_SET" sasl_password)
 NET=""
 OPTIONS=('smtp_tls_security_level' 'smtp_tls_loglevel'
 'smtp_tls_exclude_ciphers' 'smtp_tls_mandatory_ciphers'
@@ -60,7 +60,7 @@ postconf -e smtpd_recipient_restrictions="permit_mynetworks,permit_sasl_authenti
 
 
 # check if SASL authentication should be configured
-if [ -n "${POSFIX_SASL_USER}" ] && [ -n "${POSFIX_SASL_PASSWORD}" ]; then
+if [ "${POSTFIX_SASL_USER}" != "NOT_SET" ] && [ "${POSTFIX_SASL_PASSWORD}" != "NOT_SET" ]; then
       echo "found SASL pw and user ... configure Postfix to use SASL authentication"
 
       # SASL security in postfix

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -33,8 +33,8 @@ function writeIntoFileAndSetIfConfigured {
 MAILRELAY=$(doguctl config relayhost)
 NAME=$(hostname)
 DOMAIN=$(doguctl config --global domain)
-POSFIX_SASL_USER=$(doguctl config username)
-POSFIX_SASL_PASSWORD=$(doguctl config password)
+POSFIX_SASL_USER=$(doguctl config sasl_username)
+POSFIX_SASL_PASSWORD=$(doguctl config sasl_password)
 NET=""
 OPTIONS=('smtp_tls_security_level' 'smtp_tls_loglevel'
 'smtp_tls_exclude_ciphers' 'smtp_tls_mandatory_ciphers'

--- a/resources/startup.sh
+++ b/resources/startup.sh
@@ -59,7 +59,6 @@ postconf -e smtputf8_enable=no
 postconf -e smtpd_recipient_restrictions="permit_mynetworks,permit_sasl_authenticated,reject_unauth_destination"
 
 
-
 # check if SASL authentication should be configured
 if [ -n "${POSFIX_SASL_USER}" ] && [ -n "${POSFIX_SASL_PASSWORD}" ]; then
       echo "found SASL pw and user ... configure Postfix to use SASL authentication"


### PR DESCRIPTION
Resolves #13.

This PR adds configuration options that allow Postfix to communicate with mail relay servers using SASL authentication.
You only need to set the etcd keys /config/posfix/sasl_username and /config/posfix/sasl_password.